### PR TITLE
migration: load existing data per stream folder

### DIFF
--- a/invenio_rdm_migrator/streams/runner.py
+++ b/invenio_rdm_migrator/streams/runner.py
@@ -68,7 +68,7 @@ class Runner:
                 existing_data = stream_config.get("existing_data", {})
 
                 # if loading pass source data dir, else pass tmp to dump new csv files
-                stream_data_dir = self.data_dir
+                stream_data_dir = self.data_dir / definition.name
                 extract = None
                 transform = None
                 if not existing_data:


### PR DESCRIPTION
change the existing data mechanism to load data per stream as for example community files are generated file bucket and object entries. Thus, someone will need to merge these with the input data from the original files...

# Sample existing data full load
![Screenshot 2023-05-15 at 17 48 41](https://github.com/inveniosoftware/invenio-rdm-migrator/assets/22594783/666955d9-7b6d-44de-a528-7e0c22e46a07)
