### PR TITLE
global: rename cache into state

### DIFF
--- a/invenio_rdm_migrator/state/__init__.py
+++ b/invenio_rdm_migrator/state/__init__.py
@@ -5,14 +5,15 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Cache module."""
+"""State module."""
 
-from .communities import CommunitiesCache
-from .pids import PIDMaxPKCache
-from .records import ParentsCache, RecordsCache
+from .communities import CommunitiesState
+from .pids import PIDMaxPKState
+from .records import ParentsState, RecordsState
 
 __all__ = (
-    "ParentsCache",
-    "PIDMaxPKCache",
-    "RecordsCache",
+    "CommunitiesState",
+    "ParentsState",
+    "PIDMaxPKState",
+    "RecordsState",
 )

--- a/invenio_rdm_migrator/state/base.py
+++ b/invenio_rdm_migrator/state/base.py
@@ -5,55 +5,54 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Base cache module."""
-
+"""Base state module."""
 import json
 from abc import ABC, abstractmethod
 
-from ...utils import ts
+from ..utils import ts
 
 
-class Cache(ABC):
-    """Cache interface."""
+class State(ABC):
+    """State interface."""
 
     def __init__(self, filepath=None, validate=False):
         """Constructor."""
         self._data = {}
 
-        if filepath and filepath.exists():  # load cache from file
+        if filepath and filepath.exists():  # load state from file
             start = ts(iso=False)
-            print(f"Loading cache from {filepath} {ts()}")
+            print(f"Loading state from {filepath} {ts()}")
             with open(filepath, "r") as file:
                 self._data = json.loads(file.read())
 
-            print(f"Finished loading cache {ts()}")
+            print(f"Finished loading state {ts()}")
             if validate:
-                print(f"Validating cache {ts()}")
+                print(f"Validating state {ts()}")
                 for _, entry in self._data.items():
                     self._validate(entry)
-                print(f"Finished validating cache {ts()}")
+                print(f"Finished validating state {ts()}")
             end = ts(iso=False)
-            print(f"Cache loading took {end-start} seconds.")
+            print(f"State loading took {end-start} seconds.")
 
     def dump(self, filepath):
-        """Dump cache data into a json file."""
-        print(f"Dumping cache to {filepath} {ts()}")
+        """Dump state data into a json file."""
+        print(f"Dumping state to {filepath} {ts()}")
         start = ts(iso=False)
 
         with open(filepath, "w") as outfile:
             outfile.write(json.dumps(self._data))
 
         end = ts(iso=False)
-        print(f"Finished dumping cache {ts()}")
-        print(f"Cache dumping took {end-start} seconds.")
+        print(f"Finished dumping state {ts()}")
+        print(f"State dumping took {end-start} seconds.")
 
     def get(self, key):
-        """Get data from the cache."""
+        """Get data from the state."""
         key = str(key)  # in case they are numbers
         return self._data.get(key, {})
 
     def all(self):
-        """Get all the data from the cache."""
+        """Get all the data from the state."""
         return self._data.values()
 
     @abstractmethod
@@ -62,7 +61,7 @@ class Cache(ABC):
         pass
 
     def add(self, key, data):
-        """Add key to the cache.
+        """Add key to the state.
 
         :param key: recid
         """

--- a/invenio_rdm_migrator/state/communities.py
+++ b/invenio_rdm_migrator/state/communities.py
@@ -5,15 +5,15 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Communities cache module."""
+"""Communities state module."""
 
 from uuid import UUID
 
-from .base import Cache
+from .base import State
 
 
-class CommunitiesCache(Cache):
-    """Communities cache."""
+class CommunitiesState(State):
+    """Communities state."""
 
     def _validate(self, data):
         """Validate data entry."""
@@ -23,6 +23,6 @@ class CommunitiesCache(Cache):
             raise AssertionError
 
     def get(self, key):
-        """Get data from the cache."""
+        """Get data from the state."""
         key = str(key)  # in case they are numbers
         return self._data.get(key)

--- a/invenio_rdm_migrator/state/pids.py
+++ b/invenio_rdm_migrator/state/pids.py
@@ -5,24 +5,24 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""PIDs cache module."""
+"""PIDs state module."""
 
 
-from ...load.ids import initialize_pid_pk_value, pid_pk
-from .base import Cache
+from ..load.ids import initialize_pid_pk_value, pid_pk
+from .base import State
 
 
-class PIDMaxPKCache(Cache):
-    """PID max pk count cache."""
+class PIDMaxPKState(State):
+    """PID max pk count state."""
 
     def __init__(self, filepath=None, validate=False):
         """Constructor."""
         super().__init__(filepath, validate)
-        # check if max_pid cache is not empty
+        # check if max_pid state is not empty
         max_value = self._data.get("max_value")
         if max_value:
-            # set the initial value of pid_pk() to the max_value cached
-            # i.e start generating pks from the cached value and beyond
+            # set the initial value of pid_pk() to the max_value state
+            # i.e start generating pks from the state value and beyond
             initialize_pid_pk_value(max_value)
 
     def _validate(self, data):
@@ -38,7 +38,7 @@ class PIDMaxPKCache(Cache):
         raise NotImplementedError
 
     def dump(self, filepath):
-        """Dump cache data into a json file."""
+        """Dump state data into a json file."""
         max_pid_value = pid_pk.value if hasattr(pid_pk, "value") else pid_pk()
         self._data["max_value"] = max_pid_value  # update to latest current value
 

--- a/invenio_rdm_migrator/state/records.py
+++ b/invenio_rdm_migrator/state/records.py
@@ -5,13 +5,13 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Records cache module."""
+"""Records state module."""
 
-from .base import Cache
+from .base import State
 
 
-class ParentsCache(Cache):
-    """Parent record cache."""
+class ParentsState(State):
+    """Parent record state."""
 
     def _validate(self, data):
         """Validate data entry."""
@@ -21,7 +21,7 @@ class ParentsCache(Cache):
             assert data["latest_index"]
 
     def add(self, key, data):
-        """Add key to the cache.
+        """Add key to the state.
 
         :param key: the recid of the parent
         """
@@ -51,8 +51,8 @@ class ParentsCache(Cache):
             parent["next_draft_id"] = data["next_draft_id"]
 
 
-class RecordsCache(Cache):
-    """Record cache."""
+class RecordsState(State):
+    """Record state."""
 
     def _validate(self, data):
         """Validate data entry."""

--- a/invenio_rdm_migrator/streams/communities/load.py
+++ b/invenio_rdm_migrator/streams/communities/load.py
@@ -8,21 +8,21 @@
 """Invenio RDM migration users load module."""
 
 from ...load import PostgreSQLCopyLoad
-from ..cache import CommunitiesCache
+from ...state import CommunitiesState
 from .table_generator import CommunityTableGenerator
 
 
 class CommunityCopyLoad(PostgreSQLCopyLoad):
     """PostgreSQL communities COPY load."""
 
-    def __init__(self, db_uri, data_dir, cache, **kwargs):
+    def __init__(self, db_uri, data_dir, state, **kwargs):
         """Constructor."""
-        self.communities_cache = cache.get("communities", CommunitiesCache())
+        self.communities_state = state.get("communities", CommunitiesState())
         super().__init__(
             db_uri=db_uri,
             data_dir=data_dir,
             table_generators=[
-                CommunityTableGenerator(communities_cache=self.communities_cache),
+                CommunityTableGenerator(communities_state=self.communities_state),
             ],
             **kwargs,
         )

--- a/invenio_rdm_migrator/streams/communities/table_generator.py
+++ b/invenio_rdm_migrator/streams/communities/table_generator.py
@@ -29,9 +29,9 @@ def _generate_featured_community_id(data):
 class CommunityTableGenerator(TableGenerator):
     """User and related tables load."""
 
-    def __init__(self, communities_cache):
+    def __init__(self, communities_state):
         """Constructor."""
-        self.communities_cache = communities_cache
+        self.communities_state = communities_state
         super().__init__(
             tables=[
                 Community,
@@ -57,8 +57,8 @@ class CommunityTableGenerator(TableGenerator):
         community_files = data["community_files"]
         bucket = community_files["bucket"]
 
-        if not self.communities_cache.get(community_slug):
-            self.communities_cache.add(community_slug, community_id)
+        if not self.communities_state.get(community_slug):
+            self.communities_state.add(community_slug, community_id)
 
         community["bucket_id"] = bucket["id"]
         yield FilesBucket(**bucket)

--- a/invenio_rdm_migrator/streams/records/load.py
+++ b/invenio_rdm_migrator/streams/records/load.py
@@ -8,7 +8,7 @@
 """Invenio RDM migration record load module."""
 
 from ...load import PostgreSQLCopyLoad
-from ..cache import CommunitiesCache, ParentsCache, RecordsCache
+from ...state import CommunitiesState, ParentsState, RecordsState
 from .table_generators import (
     RDMDraftTableGenerator,
     RDMRecordTableGenerator,
@@ -19,26 +19,26 @@ from .table_generators import (
 class RDMRecordCopyLoad(PostgreSQLCopyLoad):
     """PostgreSQL COPY load."""
 
-    def __init__(self, db_uri, data_dir, cache, versioning=True, **kwargs):
+    def __init__(self, db_uri, data_dir, state, versioning=True, **kwargs):
         """Constructor."""
-        self.parents_cache = cache.get("parents", ParentsCache())
-        self.records_cache = cache.get("records", RecordsCache())
-        self.communities_cache = cache.get("communities", CommunitiesCache())
+        self.parents_state = state.get("parents", ParentsState())
+        self.records_state = state.get("records", RecordsState())
+        self.communities_state = state.get("communities", CommunitiesState())
         table_generators = [
             RDMRecordTableGenerator(
-                self.parents_cache,
-                self.records_cache,
-                self.communities_cache,
+                self.parents_state,
+                self.records_state,
+                self.communities_state,
             ),
             RDMDraftTableGenerator(
-                self.parents_cache,
-                self.records_cache,
-                self.communities_cache,
+                self.parents_state,
+                self.records_state,
+                self.communities_state,
             ),
         ]
 
         if versioning:
-            table_generators.append(RDMVersionStateTableGenerator(self.parents_cache))
+            table_generators.append(RDMVersionStateTableGenerator(self.parents_state))
 
         super().__init__(
             db_uri=db_uri,

--- a/invenio_rdm_migrator/streams/records/table_generators/versions.py
+++ b/invenio_rdm_migrator/streams/records/table_generators/versions.py
@@ -14,10 +14,10 @@ from ..models import RDMVersionState
 class RDMVersionStateTableGenerator(TableGenerator):
     """RDM version state computed table."""
 
-    def __init__(self, parents_cache):
+    def __init__(self, parents_state):
         """Constructor."""
         super().__init__(tables=[RDMVersionState])
-        self.parents_cache = parents_cache
+        self.parents_state = parents_state
 
     def _generate_rows(self, parent_entry, **kwargs):
         # Version state to be populated in the end from the final state
@@ -34,6 +34,6 @@ class RDMVersionStateTableGenerator(TableGenerator):
         pass
 
     def post_prepare(self, tmp_dir, stack, output_files, **kwargs):
-        """Overwrite entries with parent cache entries."""
-        for entry in self.parents_cache.all():
+        """Overwrite entries with parent state entries."""
+        for entry in self.parents_state.all():
             super().prepare(tmp_dir, entry, stack, output_files, **kwargs)

--- a/invenio_rdm_migrator/streams/requests/load.py
+++ b/invenio_rdm_migrator/streams/requests/load.py
@@ -8,21 +8,21 @@
 """Invenio RDM migration requests load module."""
 
 from ...load import PostgreSQLCopyLoad
-from ..cache import CommunitiesCache
+from ...state import CommunitiesState
 from .table_generator import RequestTableGenerator
 
 
 class RequestCopyLoad(PostgreSQLCopyLoad):
     """PostgreSQL COPY load."""
 
-    def __init__(self, db_uri, data_dir, cache, **kwargs):
+    def __init__(self, db_uri, data_dir, state, **kwargs):
         """Constructor."""
-        self.communities_cache = cache.get("communities", CommunitiesCache())
+        self.communities_state = state.get("communities", CommunitiesState())
         super().__init__(
             db_uri=db_uri,
             data_dir=data_dir,
             table_generators=[
-                RequestTableGenerator(self.communities_cache),
+                RequestTableGenerator(self.communities_state),
             ],
             **kwargs,
         )

--- a/invenio_rdm_migrator/streams/requests/table_generator.py
+++ b/invenio_rdm_migrator/streams/requests/table_generator.py
@@ -15,13 +15,13 @@ from .models import RequestMetadata
 class RequestTableGenerator(TableGenerator):
     """Requests and related tables load."""
 
-    def __init__(self, communities_cache):
+    def __init__(self, communities_state):
         """Constructor."""
         super().__init__(
             tables=[RequestMetadata],
             pks=[("id", generate_uuid)],
         )
-        self.communities_cache = communities_cache
+        self.communities_state = communities_state
 
     def _generate_rows(self, data, **kwargs):
         """Yield requests metadata."""
@@ -42,11 +42,11 @@ class RequestTableGenerator(TableGenerator):
         Translates community slugs to uuids, and record parent pids to uuids. Both values
         are mandatory, therefore they are access as dict.
 
-        :raises: KeyError if the the parent or community are not found in the cache.
+        :raises: KeyError if the the parent or community are not found in the state.
         """
         # it assumes the data is transformed by an InclusionRequestEntry
         request_slug = data["json"]["receiver"]["community"]
-        community_id = self.communities_cache.get(request_slug)
+        community_id = self.communities_state.get(request_slug)
 
         data["json"]["receiver"]["community"] = community_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,7 @@ import tempfile
 
 import pytest
 
-from invenio_rdm_migrator.streams.cache import (
-    CommunitiesCache,
-    ParentsCache,
-    RecordsCache,
-)
+from invenio_rdm_migrator.state import CommunitiesState, ParentsState, RecordsState
 
 
 @pytest.fixture(scope="function")
@@ -27,13 +23,13 @@ def tmp_dir():
 
 
 @pytest.fixture(scope="function")
-def parents_cache():
-    """Records parent cache.
+def parents_state():
+    """Records parent state.
 
     Keys are concept recids and values are dictionaries.
     """
-    cache = ParentsCache()
-    cache.add(
+    state = ParentsState()
+    state.add(
         "123456",
         {
             "id": "1234abcd-1234-5678-abcd-123abc456def",
@@ -41,37 +37,37 @@ def parents_cache():
             "latest_index": 1,
         },
     )
-    return cache
+    return state
 
 
 @pytest.fixture(scope="function")
-def records_cache():
-    """Records cache.
+def records_state():
+    """Records state.
 
     Keys are recids and values are dictionaries.
     """
-    cache = RecordsCache()
-    return cache
+    state = RecordsState()
+    return state
 
 
 @pytest.fixture(scope="function")
-def communities_cache():
-    """Communities cache.
+def communities_state():
+    """Communities state.
 
     Keys are community slugs and values are UUIDs.
     """
-    cache = CommunitiesCache()
-    cache.add("comm", "12345678-abcd-1a2b-3c4d-123abc456def")
-    cache.add("other-comm", "12345678-abcd-1a2b-3c4d-123abc123abc")
+    state = CommunitiesState()
+    state.add("comm", "12345678-abcd-1a2b-3c4d-123abc456def")
+    state.add("other-comm", "12345678-abcd-1a2b-3c4d-123abc123abc")
 
-    return cache
+    return state
 
 
 @pytest.fixture(scope="function")
-def cache(parents_cache, records_cache, communities_cache):
-    """Global cache containing the other ones."""
+def state(parents_state, records_state, communities_state):
+    """Global state containing the other ones."""
     return {
-        "parents": parents_cache,
-        "records": records_cache,
-        "communities": communities_cache,
+        "parents": parents_state,
+        "records": records_state,
+        "communities": communities_state,
     }

--- a/tests/streams/communities/test_communities_load.py
+++ b/tests/streams/communities/test_communities_load.py
@@ -16,10 +16,10 @@ from invenio_rdm_migrator.streams.communities import CommunityCopyLoad
 
 
 @pytest.fixture(scope="function")
-def community_copy_load(cache, tmp_dir):
+def community_copy_load(state, tmp_dir):
     """Community load instance."""
     # the db queries will be mocked
-    load = CommunityCopyLoad("None", tmp_dir.name, cache)
+    load = CommunityCopyLoad("None", tmp_dir.name, state)
     yield load
     load._cleanup()
 

--- a/tests/streams/communities/test_communities_table_generator.py
+++ b/tests/streams/communities/test_communities_table_generator.py
@@ -8,7 +8,7 @@
 """Communities table generator tests."""
 
 
-from invenio_rdm_migrator.streams.cache import CommunitiesCache
+from invenio_rdm_migrator.state import CommunitiesState
 from invenio_rdm_migrator.streams.communities.load import CommunityTableGenerator
 from invenio_rdm_migrator.streams.communities.models import (
     Community,
@@ -20,7 +20,7 @@ from invenio_rdm_migrator.streams.files.models import FilesBucket, FilesObjectVe
 
 def test_generate_rows(transformed_community_entry_pks):
     """Test the row generation of the request table generator."""
-    tg = CommunityTableGenerator(CommunitiesCache())
+    tg = CommunityTableGenerator(CommunitiesState())
     rows = list(tg._generate_rows(transformed_community_entry_pks))
     expected_rows = [
         FilesBucket(

--- a/tests/streams/records/test_records_table_generator.py
+++ b/tests/streams/records/test_records_table_generator.py
@@ -71,17 +71,17 @@ def mock_pid_pk():
     MockDateTime(),
 )
 def test_single_record_generate_rows(
-    cache, restart_pid_pk, transformed_record_entry_pks
+    state, restart_pid_pk, transformed_record_entry_pks
 ):
-    """A published record with a non cached parent.
+    """A published record with a non state parent.
 
-    It does not make sense to also test with a cached parent since that would mean
+    It does not make sense to also test with a state parent since that would mean
     there was a previous version of the record, which is tested separately in this module.
     """
     tg = RDMRecordTableGenerator(
-        parents_cache=cache["parents"],
-        records_cache=cache["records"],
-        communities_cache=cache["communities"],
+        parents_state=state["parents"],
+        records_state=state["records"],
+        communities_state=state["communities"],
     )
     rows = list(tg._generate_rows(transformed_record_entry_pks))
     expected_rows = [
@@ -185,8 +185,8 @@ def test_single_record_generate_rows(
 
     assert rows == expected_rows
 
-    assert len(cache["parents"].all()) == 2  # pre-existing and new
-    assert len(cache["records"].all()) == 1
+    assert len(state["parents"].all()) == 2  # pre-existing and new
+    assert len(state["records"].all()) == 1
 
 
 @patch(
@@ -200,12 +200,12 @@ def test_single_record_generate_rows(
     "invenio_rdm_migrator.streams.records.table_generators.parents.datetime",
     MockDateTime(),
 )
-def test_single_draft_generate_rows(cache, restart_pid_pk, transformed_draft_entry_pks):
+def test_single_draft_generate_rows(state, restart_pid_pk, transformed_draft_entry_pks):
     """A new draft, not published."""
     tg = RDMDraftTableGenerator(
-        parents_cache=cache["parents"],
-        records_cache=cache["records"],
-        communities_cache=cache["communities"],
+        parents_state=state["parents"],
+        records_state=state["records"],
+        communities_state=state["communities"],
     )
     rows = list(tg._generate_rows(transformed_draft_entry_pks))
     expected_rows = [
@@ -281,8 +281,8 @@ def test_single_draft_generate_rows(cache, restart_pid_pk, transformed_draft_ent
 
     assert rows == expected_rows
 
-    assert len(cache["parents"].all()) == 2  # pre-existing and new
-    assert len(cache["records"].all()) == 0
+    assert len(state["parents"].all()) == 2  # pre-existing and new
+    assert len(state["records"].all()) == 0
 
 
 @patch(
@@ -304,19 +304,19 @@ def test_single_draft_generate_rows(cache, restart_pid_pk, transformed_draft_ent
     MockDateTime(),
 )
 def test_record_versions_and_old_draft_generate_rows(
-    cache, restart_pid_pk, transformed_record_entry_pks, transformed_draft_entry_pks
+    state, restart_pid_pk, transformed_record_entry_pks, transformed_draft_entry_pks
 ):
     """A record with two versions (v1, v2) and a draft of the first version (v1)."""
     tgs = [
         RDMRecordTableGenerator(
-            parents_cache=cache["parents"],
-            records_cache=cache["records"],
-            communities_cache=cache["communities"],
+            parents_state=state["parents"],
+            records_state=state["records"],
+            communities_state=state["communities"],
         ),
         RDMDraftTableGenerator(
-            parents_cache=cache["parents"],
-            records_cache=cache["records"],
-            communities_cache=cache["communities"],
+            parents_state=state["parents"],
+            records_state=state["records"],
+            communities_state=state["communities"],
         ),
     ]
 
@@ -436,8 +436,8 @@ def test_record_versions_and_old_draft_generate_rows(
     assert rows[7:11] == expected_rows_v2
     assert rows[11:12] == expected_rows_d_v1
 
-    assert len(cache["parents"].all()) == 2  # pre-existing and new
-    assert len(cache["records"].all()) == 2  # two added records
+    assert len(state["parents"].all()) == 2  # pre-existing and new
+    assert len(state["records"].all()) == 2  # two added records
 
 
 @patch(
@@ -459,19 +459,19 @@ def test_record_versions_and_old_draft_generate_rows(
     MockDateTime(),
 )
 def test_record_and_new_version_draft_generate_rows(
-    cache, restart_pid_pk, transformed_record_entry_pks, transformed_draft_entry_pks
+    state, restart_pid_pk, transformed_record_entry_pks, transformed_draft_entry_pks
 ):
     """A published record (v1) with a new version draft (v2)."""
     tgs = [
         RDMRecordTableGenerator(
-            parents_cache=cache["parents"],
-            records_cache=cache["records"],
-            communities_cache=cache["communities"],
+            parents_state=state["parents"],
+            records_state=state["records"],
+            communities_state=state["communities"],
         ),
         RDMDraftTableGenerator(
-            parents_cache=cache["parents"],
-            records_cache=cache["records"],
-            communities_cache=cache["communities"],
+            parents_state=state["parents"],
+            records_state=state["records"],
+            communities_state=state["communities"],
         ),
     ]
 
@@ -539,5 +539,5 @@ def test_record_and_new_version_draft_generate_rows(
     # v2 rows not asserted since they are checked at test_record_versions_and_old_draft_generate_rows
     assert rows[11:13] == expected_rows_d_v3
 
-    assert len(cache["parents"].all()) == 2  # pre-existing and new
-    assert len(cache["records"].all()) == 2  # two added records
+    assert len(state["parents"].all()) == 2  # pre-existing and new
+    assert len(state["records"].all()) == 2  # two added records

--- a/tests/streams/requests/test_requests_load.py
+++ b/tests/streams/requests/test_requests_load.py
@@ -16,10 +16,10 @@ from invenio_rdm_migrator.streams.requests import RequestCopyLoad
 
 
 @pytest.fixture(scope="function")
-def request_copy_load(cache, tmp_dir):
+def request_copy_load(state, tmp_dir):
     """Request load instance."""
     # the db queries will be mocked
-    load = RequestCopyLoad("None", tmp_dir.name, cache)
+    load = RequestCopyLoad("None", tmp_dir.name, state)
     yield load
     load._cleanup()
 

--- a/tests/streams/requests/test_requests_table_generator.py
+++ b/tests/streams/requests/test_requests_table_generator.py
@@ -17,7 +17,7 @@ from invenio_rdm_migrator.streams.requests.models import RequestMetadata
 
 def test_generate_rows(transformed_incl_req_entry_pks):
     """Test the row generation of the request table generator."""
-    tg = RequestTableGenerator(None)  # no need for cache in this test
+    tg = RequestTableGenerator(None)  # no need for state in this test
     rows = list(tg._generate_rows(transformed_incl_req_entry_pks))
     expected_rows = [
         RequestMetadata(
@@ -42,12 +42,12 @@ def test_generate_rows(transformed_incl_req_entry_pks):
     assert rows == expected_rows
 
 
-def test_resolve_references(communities_cache, transformed_incl_req_entry_pks):
+def test_resolve_references(communities_state, transformed_incl_req_entry_pks):
     """Test the parent and community reference resolution."""
     expected = deepcopy(transformed_incl_req_entry_pks)
     expected["json"]["receiver"]["community"] = "12345678-abcd-1a2b-3c4d-123abc456def"
 
-    tg = RequestTableGenerator(communities_cache)
+    tg = RequestTableGenerator(communities_state)
     tg._resolve_references(transformed_incl_req_entry_pks)  # changes in place
 
     assert not list(dictdiffer.diff(transformed_incl_req_entry_pks, expected))

--- a/tests/streams/test_cache.py
+++ b/tests/streams/test_cache.py
@@ -5,7 +5,7 @@
 # Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Cache tests."""
+"""State tests."""
 
 import json
 from pathlib import Path
@@ -13,27 +13,27 @@ from pathlib import Path
 import pytest
 
 from invenio_rdm_migrator.load.ids import pid_pk
-from invenio_rdm_migrator.streams.cache import (
-    CommunitiesCache,
-    ParentsCache,
-    PIDMaxPKCache,
-    RecordsCache,
+from invenio_rdm_migrator.state import (
+    CommunitiesState,
+    ParentsState,
+    PIDMaxPKState,
+    RecordsState,
 )
-from invenio_rdm_migrator.streams.cache.base import Cache
+from invenio_rdm_migrator.state.base import State
 
 ###
-# Parent Cache
+# Parent State
 ###
 
 
 @pytest.fixture(scope="function")
-def parents_cache():
-    """Parents cache."""
-    return ParentsCache()
+def parents_state():
+    """Parents state."""
+    return ParentsState()
 
 
-def test_parent_cache_record_entry(parents_cache):
-    parents_cache.add(
+def test_parent_state_record_entry(parents_state):
+    parents_state.add(
         "123",
         {
             "id": "parent-uuid",
@@ -41,24 +41,24 @@ def test_parent_cache_record_entry(parents_cache):
             "latest_id": "record-uuid",
         },
     )
-    assert parents_cache.get("123")
-    assert parents_cache.get(123)  # test num to string conversion
+    assert parents_state.get("123")
+    assert parents_state.get(123)  # test num to string conversion
 
 
-def test_parent_cache_draft_entry(parents_cache):
-    parents_cache.add(
+def test_parent_state_draft_entry(parents_state):
+    parents_state.add(
         "123",
         {
             "id": "parent-uuid",
             "next_draft_id": "draft-uuid",
         },
     )
-    assert parents_cache.get("123")
-    assert parents_cache.get(123)  # test num to string conversion
+    assert parents_state.get("123")
+    assert parents_state.get(123)  # test num to string conversion
 
 
-def test_parent_cache_update_record(parents_cache):
-    parents_cache.add(
+def test_parent_state_update_record(parents_state):
+    parents_state.add(
         "123",
         {
             "id": "parent-uuid",
@@ -66,21 +66,21 @@ def test_parent_cache_update_record(parents_cache):
             "latest_id": "record-uuid",
         },
     )
-    assert not parents_cache.get("123").get("next_draft_id")
+    assert not parents_state.get("123").get("next_draft_id")
 
-    parents_cache.update(
+    parents_state.update(
         "123",
         {
             "latest_index": 100,
             "latest_id": "new-record-uuid",
         },
     )
-    assert parents_cache.get("123").get("latest_index") == 100
-    assert parents_cache.get("123").get("latest_id") == "new-record-uuid"
+    assert parents_state.get("123").get("latest_index") == 100
+    assert parents_state.get("123").get("latest_id") == "new-record-uuid"
 
 
-def test_parent_cache_update_draft(parents_cache):
-    parents_cache.add(
+def test_parent_state_update_draft(parents_state):
+    parents_state.add(
         "123",
         {
             "id": "parent-uuid",
@@ -88,18 +88,18 @@ def test_parent_cache_update_draft(parents_cache):
             "latest_id": "record-uuid",
         },
     )
-    assert not parents_cache.get("123").get("next_draft_id")
+    assert not parents_state.get("123").get("next_draft_id")
 
-    parents_cache.update(
+    parents_state.update(
         "123",
         {
             "next_draft_id": "draft-uuid",
         },
     )
-    assert parents_cache.get("123").get("next_draft_id") == "draft-uuid"
+    assert parents_state.get("123").get("next_draft_id") == "draft-uuid"
 
 
-def test_parent_cache_invalid_entries(parents_cache):
+def test_parent_state_invalid_entries(parents_state):
     invalid = [
         {  # no id
             "latest_index": 1,
@@ -116,22 +116,22 @@ def test_parent_cache_invalid_entries(parents_cache):
     ]
 
     for entry in invalid:
-        pytest.raises(AssertionError, parents_cache.add, "123", entry)
+        pytest.raises(AssertionError, parents_state.add, "123", entry)
 
 
 ###
-# Record Cache
+# Record State
 ###
 
 
 @pytest.fixture(scope="function")
-def records_cache():
-    """Records cache."""
-    return RecordsCache()
+def records_state():
+    """Records state."""
+    return RecordsState()
 
 
-def test_record_cache_record_entry(records_cache):
-    records_cache.add(
+def test_record_state_record_entry(records_state):
+    records_state.add(
         "123",
         {
             "index": 1,
@@ -140,11 +140,11 @@ def test_record_cache_record_entry(records_cache):
             "fork_version_id": 1,
         },
     )
-    assert records_cache.get("123")
-    assert records_cache.get(123)  # test num to string conversion
+    assert records_state.get("123")
+    assert records_state.get(123)  # test num to string conversion
 
 
-def test_record_cache_invalid_entries(records_cache):
+def test_record_state_invalid_entries(records_state):
     invalid = [
         {
             "id": "record-uuid",
@@ -169,16 +169,16 @@ def test_record_cache_invalid_entries(records_cache):
     ]
 
     for entry in invalid:
-        pytest.raises(AssertionError, records_cache.add, "123", entry)
+        pytest.raises(AssertionError, records_state.add, "123", entry)
 
 
 ###
-# Cache
+# State
 ###
 
 
-class MockCache(Cache):
-    """Mock Cache."""
+class MockState(State):
+    """Mock State."""
 
     def _validate(self, data):
         """Validate data value is not 2."""
@@ -187,7 +187,7 @@ class MockCache(Cache):
 
 @pytest.fixture(scope="function")
 def data_file(tmp_dir):
-    """Cache data filepath."""
+    """State data filepath."""
     filepath = Path(tmp_dir.name) / "data.json"
     with open(filepath, "w") as file:
         file.write(json.dumps({"one": {"value": 1}, "two": {"value": 2}}))
@@ -195,31 +195,31 @@ def data_file(tmp_dir):
     return filepath
 
 
-def test_cache_from_source_data_no_validation(data_file):
-    """Test creating a cache with initial data."""
-    cache = MockCache(data_file)
+def test_state_from_source_data_no_validation(data_file):
+    """Test creating a state with initial data."""
+    state = MockState(data_file)
 
-    assert cache.get("one")
-    assert cache.get("two")
-    assert len(cache.all()) == 2
+    assert state.get("one")
+    assert state.get("two")
+    assert len(state.all()) == 2
 
 
-def test_cache_from_source_data_with_validation(data_file):
-    """Test creating a cache with initial data."""
+def test_state_from_source_data_with_validation(data_file):
+    """Test creating a state with initial data."""
     with pytest.raises(AssertionError):
-        _ = MockCache(data_file, validate=True)
+        _ = MockState(data_file, validate=True)
 
 
-def test_cache_dump_data(tmp_dir):
-    """Test dumping the data of the cache."""
-    cache = MockCache()
+def test_state_dump_data(tmp_dir):
+    """Test dumping the data of the state."""
+    state = MockState()
 
-    cache.add("one", {"value": 1})
-    cache.add("three", {"value": 3})
-    cache.add("four", {"value": 4})
+    state.add("one", {"value": 1})
+    state.add("three", {"value": 3})
+    state.add("four", {"value": 4})
 
     filepath = Path(tmp_dir.name) / "dump.json"
-    cache.dump(filepath)
+    state.dump(filepath)
 
     with open(filepath, "r") as file:
         expected = '{"one": {"value": 1}, "three": {"value": 3}, "four": {"value": 4}}'
@@ -228,25 +228,25 @@ def test_cache_dump_data(tmp_dir):
 
 
 ###
-# PIDMaxPK Cache
+# PIDMaxPK State
 ###
 
 
 @pytest.fixture(scope="function")
 def pid_max_pk():
-    """Max PID PK cache."""
-    return PIDMaxPKCache()
+    """Max PID PK state."""
+    return PIDMaxPKState()
 
 
-def test_pid_max_pk_cache_add(pid_max_pk):
+def test_pid_max_pk_state_add(pid_max_pk):
     pytest.raises(NotImplementedError, pid_max_pk.add, "key", "value")
 
 
-def test_pid_max_pk_cache_update(pid_max_pk):
+def test_pid_max_pk_state_update(pid_max_pk):
     pytest.raises(NotImplementedError, pid_max_pk.update, "max_value", "value")
 
 
-def test_pid_max_pk_cache_dump(tmp_dir, pid_max_pk):
+def test_pid_max_pk_state_dump(tmp_dir, pid_max_pk):
     filepath = Path(tmp_dir.name) / "dump.json"
     pid_pk()
     pid_max_pk.dump(filepath)
@@ -258,42 +258,42 @@ def test_pid_max_pk_cache_dump(tmp_dir, pid_max_pk):
         assert content == expected
 
 
-def test_pid_max_pk_cache_load(tmp_dir):
+def test_pid_max_pk_state_load(tmp_dir):
     filepath = Path(tmp_dir.name) / "dump.json"
     with open(filepath, "w") as file:
         file.write(json.dumps({"max_value": 10}))
 
-    cache = PIDMaxPKCache(filepath, validate=True)
-    assert cache.get("max_value") == 10
+    state = PIDMaxPKState(filepath, validate=True)
+    assert state.get("max_value") == 10
 
 
-def test_pid_max_pk_cache_validation_no_int(tmp_dir):
+def test_pid_max_pk_state_validation_no_int(tmp_dir):
     # loading an int is tested implicitly in the previous test
     filepath = Path(tmp_dir.name) / "dump.json"
     with open(filepath, "w") as file:
         file.write(json.dumps({"max_value": "10"}))
 
     with pytest.raises(AssertionError):
-        PIDMaxPKCache(filepath, validate=True)
+        PIDMaxPKState(filepath, validate=True)
 
 
 ###
-# Communities cache
+# Communities state
 ###
 
 
-def test_communities_cache_validation_no_uuid(tmp_dir):
+def test_communities_state_validation_no_uuid(tmp_dir):
     filepath = Path(tmp_dir.name) / "dump.json"
     with open(filepath, "w") as file:
         file.write(json.dumps({"max_value": "10"}))
 
     with pytest.raises(AssertionError):
-        CommunitiesCache(filepath, validate=True)
+        CommunitiesState(filepath, validate=True)
 
 
-def test_communities_cache_get():
-    cache = CommunitiesCache()
-    cache.add("exists", "12345678-abcd-1a2b-3c4d-123abc456def")
+def test_communities_state_get():
+    state = CommunitiesState()
+    state.add("exists", "12345678-abcd-1a2b-3c4d-123abc456def")
 
-    assert not cache.get("other")
-    assert cache.get("exists") == "12345678-abcd-1a2b-3c4d-123abc456def"
+    assert not state.get("other")
+    assert state.get("exists") == "12345678-abcd-1a2b-3c4d-123abc456def"


### PR DESCRIPTION
- partly closes https://github.com/inveniosoftware/invenio-rdm-migrator/issues/96

**IMPORTANT NOTE**

This PR is a mere renaming, without functionality change. It is done independently to avoid piling up file changes in PRs.