### PR TITLE
[WIP] load: implement logic for update/delete

### DIFF
--- a/invenio_rdm_migrator/load/postgresql.py
+++ b/invenio_rdm_migrator/load/postgresql.py
@@ -108,6 +108,10 @@ class PostgreSQLCopyLoad(Load):
             for table in table_entries:
                 name = table._table_name
                 cols = ", ".join([f.name for f in fields(table)])
+                # FIXME: we will need to adapt this to go through different folders
+                # or distinguish filename with update_/delete_/insert_
+                # maybe it should be `load` who does this, since after
+                # there will be not only a COPY but more SQL stmts executed on up/delete
                 fpath = self.data_dir / f"{name}.csv"
                 if fpath.exists():
                     # total file size for progress logging
@@ -230,7 +234,9 @@ class TableGenerator(ABC):
         self._generate_pks(entry, kwargs.get("create", False))
         # resolve entry references
         self._resolve_references(entry)
-        for entry in self._generate_rows(entry):
+        for action, entry in self._generate_rows(entry):
+            # FIXME: needs split per action on the csv file
+            # in the file name? or in the path?
             if entry._table_name not in output_files:
                 fpath = tmp_dir / f"{entry._table_name}.csv"
                 output_files[entry._table_name] = csv.writer(

--- a/invenio_rdm_migrator/load/statements.py
+++ b/invenio_rdm_migrator/load/statements.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statement module."""
+
+from enum import Enum
+
+
+class Statement(Enum):
+    """Represents the possible SQL operations supported by the migrator."""
+
+    INSERT = "I"
+    UPDATE = "U"
+    DELETE = "D"


### PR DESCRIPTION
- closes #102 

Comments and minor modifications to identify where the codes needs to be refactored to support `UPDATE` and `DELETE` statements. This changes affect only the `**L**oad` step.

Topics to discuss [copying text from here](https://github.com/inveniosoftware/invenio-rdm-migrator/issues/6#issuecomment-1593179127):

> On a differential run we should execute: new inserts, then the question is between updates and deletes. It could be both cases:
1) a record is updated, then deleted
2) a record is deleted, then restored (update).
3) both above concatenated in any order

> An option (a) would be to have the cursors run operation batches based on timestamp ranges.
This could lead to very inefficient performance in the worst case when batches are fully
intertwined (i.e. 1 update, 1 delete, 1 update, 1 delete, etc.)

> Another option (b) is to semantically group operations to render the record in the last known
state, e.g. deleted, or updated with X metadata. This option requires more logic and a larger
implementation effort, but it might be the more performant.

## Proposal

- Having two pipelines, one for inserts and one for update/deletes.
- The **E**xtract step would have sort of a "post hook" that will route the message to one or the other pipeline depending on the `op` field of the payload (see annex below).
- The two pipelines would be executed sequentially, being the `inserts` first one. Since the only case possible is that it is afterward updated and/or deleted. But no entity can be "re-insterted", that is an update. Therefore, there is no out-of-order possibility.
- The main case to deal with order execution of `update` and `delete` of the same record/file/<entity> within the same batch. These are the cases mentioned at the beginning of the issue (1, 2, 3). If they are in separate batches, it means they are processed in the same order they occurred on the system. 

**In-order processing of updates and deletes**
Instead of doing the full ETL and saving to a csv in the `Load.prepare` step, these woudl be saved to the state along with a timestamp (updated time in the original system/Zenodo) and a deletion mark. Therefore, both update and delete can be "prepared" together.
- The timestamp serves the purpose of optimistic version control. If an update comes in with an earlier timestamp the changes are applied in the state, even if a record is currently mark for deletion this is needed in case of subsequent "restore".
- The deletion mark serves for filtering.
- The global state will store the latest differential time. Therefore, we can create the bulk statements in a similar fashion to the versioning table:
    - All updates with update date newer than the latest differential run time and not marked for deletion are executed in bulk
    - All mark for deletion with update date newer than the latest differential run time are executed in bulk

While this method would allow us to "filter" the database logical logs, for example, seeing a record insert or update would contain all the information needed for the load step to generate the corresponding rows. So all other sql logs related to that operation (e.g. files, pids, etc.) can be filtered out. This will cause new "streams" to appear. For example, a "pids" stream. A record restore is better identified by a PID status change (update). This operations need to be identified.

## Annex: pypgoutput logs for a record creation and update.

Things to take into account:
- Ignoring files_files op U (file integrity checks), How to distinguish from actual updates.
- Ignoring transaction, records revision, sipstore and other tables
- Group by transaction ID, could subgroup by relation ID

[pypgoutput_test.md](https://github.com/inveniosoftware/invenio-rdm-migrator/files/11787976/pypgoutput_test.md)

