### PR TITLE
Migration fixes

### DIFF
--- a/invenio_rdm_migrator/actions/base.py
+++ b/invenio_rdm_migrator/actions/base.py
@@ -62,7 +62,7 @@ class LoadAction(Action, ABC):
         self.data = self.data_cls(**data)
         super().__init__()
 
-    def _generate_pks(self):
+    def _generate_pks(self, session: orm.Session = None):
         for attr_name, path, pk_func in self.pks:
             try:
                 attr = getattr(self.data, attr_name)
@@ -75,24 +75,24 @@ class LoadAction(Action, ABC):
                 logger = Logger.get_logger()
                 logger.exception(f"Path {path} not found on record", exc_info=1)
 
-    def _resolve_references(self, **kwargs):  # pragma: no cover
+    def _resolve_references(self, session: orm.Session = None, **kwargs):
         """Resolve references e.g communities slug names."""
         pass
 
     @abstractmethod
-    def _generate_rows(self, **kwargs):  # pragma: no cover
+    def _generate_rows(self, session: orm.Session = None, **kwargs):
         """Yield generated rows."""
 
-    def prepare(self, **kwargs):
+    def prepare(self, session: orm.Session, **kwargs):
         """Generate the SQL statements required to persist the action.
 
         Any required data should be part of the instance attributes.
         """
         # is_db_empty would come in play and make _generate_pks optional
-        self._generate_pks()
+        self._generate_pks(session=session)
         # resolve entry references
-        self._resolve_references()
-        yield from self._generate_rows(**kwargs)
+        self._resolve_references(session=session)
+        yield from self._generate_rows(session=session, **kwargs)
 
 
 class TransformAction(Action, DatetimeMixin, ABC):

--- a/invenio_rdm_migrator/extract/transactions.py
+++ b/invenio_rdm_migrator/extract/transactions.py
@@ -18,3 +18,39 @@ class Tx:
     id: int
     operations: list[dict]  # TODO: we could more narrowly define it later
     commit_lsn: Optional[int] = None
+
+    def as_ops_tuples(self, include=None):
+        """Return a list of (table, op_type) tuples."""
+        if include is None:
+            return [(o["source"]["table"], o["op"]) for o in self.operartions]
+        else:
+            return [
+                (table, o["op"])
+                for o in self.operartions
+                if (table := o["source"]["table"]) in include
+            ]
+
+    def ops_by(self, table, pk: tuple[str] = None):
+        """Return rolled-up and/or grouped table operations."""
+        res = {}
+        for operation in self.operations:
+            table_name = operation["source"]["table"]
+            before = operation["before"]
+            after = operation["after"]
+            data = after or before
+            if table_name == table:
+                if pk:  # group by PK
+                    key = tuple(data[k] for k in pk)
+                    res.setdefault(key, {})
+                    res[key].update(data)
+                else:
+                    res.update(data)
+
+    def filter_ops(self, table, filter: dict):
+        """Return rolled-up and/or grouped table operations."""
+        return [
+            o
+            for o in self.operartions
+            if o["source"]["table"] == table
+            and filter.items() <= (o["after"] or o["before"]).items()
+        ]

--- a/invenio_rdm_migrator/load/ids.py
+++ b/invenio_rdm_migrator/load/ids.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from ..state import STATE
 
 
-def generate_uuid(data):
+def generate_uuid(data=None):
     """Generate a UUID."""
     return str(uuid4())
 
@@ -31,7 +31,7 @@ def pid_pk():
     return value
 
 
-def generate_pk(data):
+def generate_pk(data=None):
     """Generate a primary key."""
     return pid_pk()
 
@@ -43,7 +43,7 @@ def generate_pk_for(model_cls):
     "max_{model.__tablename__}_pk".
     """
 
-    def _pk_gen(_):
+    def _pk_gen(_=None):
         state = STATE.VALUES
         key = f"max_{model_cls.__tablename__}_pk"
         state_value = state.get(key)
@@ -58,7 +58,7 @@ def generate_pk_for(model_cls):
     return _pk_gen
 
 
-def generate_recid(data, status="R"):
+def generate_recid(data=None, status="R"):
     """Generate a record id object."""
     # pk is not the pid_value, that comes from rec.json.id in the tg
     return {

--- a/invenio_rdm_migrator/load/postgresql/bulk/generators/table.py
+++ b/invenio_rdm_migrator/load/postgresql/bulk/generators/table.py
@@ -25,7 +25,7 @@ def as_csv_row(dc):
         if val:
             if issubclass(f.type, (dict,)):
                 val = orjson.dumps(val).decode("utf-8")
-            elif issubclass(f.type, (datetime,)):
+            elif issubclass(f.type, (datetime,)) and isinstance(val, (datetime,)):
                 val = val.isoformat()
             elif issubclass(f.type, (UUID,)):
                 val = str(val)

--- a/invenio_rdm_migrator/streams/actions/load/__init__.py
+++ b/invenio_rdm_migrator/streams/actions/load/__init__.py
@@ -12,8 +12,13 @@ from .communities import (
     CommunityDeleteAction,
     CommunityUpdateAction,
 )
-from .drafts import DraftCreateAction, DraftEditAction, DraftPublishAction
-from .files import DraftFileUploadAction
+from .drafts import DraftCreateAction, DraftEditAction, DraftPublishNewAction
+from .files import (
+    FileDeleteAction,
+    FileUploadAction,
+    MediaFileDeleteAction,
+    MediaFileUploadAction,
+)
 from .github import (
     HookEventCreateAction,
     HookEventUpdateAction,
@@ -43,8 +48,11 @@ __all__ = (
     "CommunityUpdateAction",
     "DraftCreateAction",
     "DraftEditAction",
-    "DraftFileUploadAction",
-    "DraftPublishAction",
+    "FileUploadAction",
+    "FileDeleteAction",
+    "MediaFileUploadAction",
+    "MediaFileDeleteAction",
+    "DraftPublishNewAction",
     "IgnoredAction",
     "HookEventCreateAction",
     "HookEventUpdateAction",

--- a/invenio_rdm_migrator/streams/actions/load/__init__.py
+++ b/invenio_rdm_migrator/streams/actions/load/__init__.py
@@ -12,7 +12,12 @@ from .communities import (
     CommunityDeleteAction,
     CommunityUpdateAction,
 )
-from .drafts import DraftCreateAction, DraftEditAction, DraftPublishNewAction
+from .drafts import (
+    DraftCreateAction,
+    DraftEditAction,
+    DraftPublishEditAction,
+    DraftPublishNewAction,
+)
 from .files import (
     FileDeleteAction,
     FileUploadAction,
@@ -53,6 +58,7 @@ __all__ = (
     "MediaFileUploadAction",
     "MediaFileDeleteAction",
     "DraftPublishNewAction",
+    "DraftPublishEditAction",
     "IgnoredAction",
     "HookEventCreateAction",
     "HookEventUpdateAction",

--- a/invenio_rdm_migrator/streams/actions/load/drafts.py
+++ b/invenio_rdm_migrator/streams/actions/load/drafts.py
@@ -233,7 +233,7 @@ class DraftEditAction(LoadAction, CommunitiesReferencesMixin, PIDsReferencesMixi
         """Resolve references e.g communities slug names."""
         # resolve parent communities slug
         parent = self.data.parent
-        communities = parent["json"].get("communities")
+        communities = parent.get("json").get("communities")
         if communities:
             self.resolve_communities(communities)
         self.resolve_draft_pids(self.data.draft)

--- a/invenio_rdm_migrator/streams/actions/load/files.py
+++ b/invenio_rdm_migrator/streams/actions/load/files.py
@@ -40,10 +40,10 @@ class DraftFileUploadAction(LoadAction):
         # if we were to use the state for consistency checks
         # the bucket should already exist
         yield Operation(OperationType.UPDATE, FilesBucket, self.data.bucket)
+        yield Operation(OperationType.INSERT, FilesInstance, self.data.file_instance)
         yield Operation(
             OperationType.INSERT, FilesObjectVersion, self.data.object_version
         )
-        yield Operation(OperationType.INSERT, FilesInstance, self.data.file_instance)
 
         cached_bucket = STATE.BUCKETS.get(self.data.bucket["id"])
         self.data.file_record["record_id"] = cached_bucket["draft_id"]

--- a/invenio_rdm_migrator/streams/actions/load/files.py
+++ b/invenio_rdm_migrator/streams/actions/load/files.py
@@ -9,13 +9,16 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import Optional
+
+import sqlalchemy as sa
 
 from ....actions import LoadAction, LoadData
 from ....load.ids import generate_uuid
 from ....load.postgresql.transactions.operations import Operation, OperationType
 from ....state import STATE
 from ...models.files import FilesBucket, FilesInstance, FilesObjectVersion
-from ...models.records import RDMDraftFile
+from ...models.records import RDMDraftFile, RDMDraftMetadata
 
 
 @dataclass
@@ -26,14 +29,163 @@ class FileUploadData(LoadData):
     object_version: dict
     file_instance: dict
     file_record: dict
+    replaced_object_version: Optional[dict] = None
 
 
-class DraftFileUploadAction(LoadAction):
-    """RDM draft creation."""
+class FileUploadAction(LoadAction):
+    """File upload action."""
 
-    name = "draft-upload-file"
+    name = "file-upload"
     data_cls = FileUploadData
+    data: FileUploadData
     pks = [("file_record", "id", generate_uuid)]
+
+    def _generate_rows(self, session, **kwargs):
+        """Generates rows for a new draft."""
+        replaced_ov = self.data.replaced_object_version
+        new_ov = self.data.object_version
+        yield Operation(OperationType.UPDATE, FilesBucket, self.data.bucket)
+        if not replaced_ov:
+            replaced_ov_model = session.execute(
+                sa.select(FilesObjectVersion.version_id).where(
+                    FilesObjectVersion.bucket_id == self.data.bucket["id"],
+                    FilesObjectVersion.key == new_ov["key"],
+                    FilesObjectVersion.is_head.is_(True),
+                )
+            ).one_or_none()
+            if replaced_ov_model:
+                replaced_ov = {"version_id": replaced_ov_model.version_id}
+
+        if replaced_ov:
+            yield Operation(
+                OperationType.UPDATE,
+                FilesObjectVersion,
+                {"version_id": replaced_ov["version_id"], "is_head": False},
+            )
+
+        yield Operation(OperationType.INSERT, FilesInstance, self.data.file_instance)
+        yield Operation(OperationType.INSERT, FilesObjectVersion, new_ov)
+        self.data.file_record["object_version_id"] = new_ov["version_id"]
+        if replaced_ov:
+            file_record_id = session.execute(
+                sa.select(RDMDraftFile.id).where(
+                    RDMDraftFile.object_version_id == replaced_ov["version_id"],
+                )
+            ).scalar_one()
+            self.data.file_record["id"] = file_record_id
+            yield Operation(OperationType.UPDATE, RDMDraftFile, self.data.file_record)
+        else:
+            # Find draft ID
+            draft_id = session.execute(
+                sa.select(RDMDraftMetadata.id).where(
+                    RDMDraftMetadata.bucket_id == self.data.bucket["id"]
+                )
+            ).scalar_one()
+            self.data.file_record["record_id"] = draft_id
+            yield Operation(OperationType.INSERT, RDMDraftFile, self.data.file_record)
+
+
+@dataclass
+class FileDeleteData(LoadData):
+    """File delete action data."""
+
+    bucket: dict
+    deleted_object_version: dict
+    delete_marker_object_version: Optional[dict] = None
+
+
+class FileDeleteAction(LoadAction):
+    """File delete action."""
+
+    name = "file-delete"
+    data_cls = FileDeleteData
+
+    def _generate_rows(self, *, session, **kwargs):
+        """Generates rows for deleting a draft file."""
+        bucket = self.data.bucket
+        deleted_ov = self.data.deleted_object_version
+        delete_marker = self.data.delete_marker_object_version
+
+        yield Operation(OperationType.UPDATE, FilesBucket, bucket)
+
+        # We always soft delete, which means we update the old OV's is_head = False...
+        yield Operation(OperationType.UPDATE, FilesObjectVersion, deleted_ov)
+        # ...and insert a delete marker on top
+        if not delete_marker:
+            delete_marker = {
+                "version_id": generate_uuid(),
+                "bucket_id": bucket["id"],
+                "key": deleted_ov["key"],
+                "created": bucket["updated"],
+                "updated": bucket["updated"],
+                "is_head": True,
+            }
+            yield Operation(OperationType.INSERT, FilesObjectVersion, delete_marker)
+
+        # Finally we delete the draft file
+        file_record = session.scalars(
+            sa.select(RDMDraftFile).where(
+                RDMDraftFile.object_version_id == deleted_ov["id"],
+                RDMDraftFile.key == deleted_ov["key"],
+            )
+        ).one_or_none()
+        if file_record:
+            yield Operation(OperationType.DELETE, RDMDraftFile, {"id": file_record.id})
+
+
+@dataclass
+class MediaFileUploadData(LoadData):
+    """Media file upload action data."""
+
+    record: dict
+    bucket: dict
+    object_version: dict
+    file_instance: dict
+    file_record: dict
+    replaced_object_version: Optional[dict]
+
+
+class MediaFileUploadAction(LoadAction):
+    """Media file upload action."""
+
+    name = "media-file-upload"
+    data_cls = MediaFileUploadData
+    pks = [("file_record", "id", generate_uuid)]
+
+    def _generate_rows(self, **kwargs):
+        """Generates rows for a new draft."""
+        # if we were to use the state for consistency checks
+        # the bucket should already exist
+        yield Operation(OperationType.UPDATE, FilesBucket, self.data.bucket)
+        yield Operation(OperationType.INSERT, FilesInstance, self.data.file_instance)
+        yield Operation(
+            OperationType.INSERT, FilesObjectVersion, self.data.object_version
+        )
+
+        cached_bucket = STATE.BUCKETS.get(self.data.bucket["id"])
+        self.data.file_record["record_id"] = cached_bucket["draft_id"]
+
+        _cache_fr_data = deepcopy(self.data.file_record)
+        STATE.FILE_RECORDS.add(_cache_fr_data.pop("id"), _cache_fr_data)
+
+        yield Operation(OperationType.INSERT, RDMDraftFile, self.data.file_record)
+
+
+@dataclass
+class MediaFileDeleteData(LoadData):
+    """Media file delete action data."""
+
+    bucket: dict
+    object_version: dict
+    file_instance: dict
+    file_record: dict
+
+
+class MediaFileDeleteAction(LoadAction):
+    """Media file delete action."""
+
+    name = "media-file-delete"
+    data_cls = MediaFileDeleteData
 
     def _generate_rows(self, **kwargs):
         """Generates rows for a new draft."""

--- a/invenio_rdm_migrator/streams/actions/load/users.py
+++ b/invenio_rdm_migrator/streams/actions/load/users.py
@@ -74,16 +74,6 @@ class UserProfileEditAction(LoadAction):
 
     name = "edit-user-profile"
 
-    def __init__(
-        self,
-        tx_id,
-        profile,
-    ):
-        """Constructor."""
-        super().__init__(tx_id)
-        assert profile  # i.e. not None as parameter
-        self.profile = profile
-
     def _generate_rows(self, **kwargs):
         """Generates rows for a new draft."""
         pass

--- a/invenio_rdm_migrator/streams/communities/transform.py
+++ b/invenio_rdm_migrator/streams/communities/transform.py
@@ -54,6 +54,10 @@ class CommunityTransform(Transform):
 class CommunityEntry(Entry):
     """Transform a single community entry."""
 
+    def _schema(self, entry):
+        """Return JSONSchema of the community."""
+        return "local://communities/communities-v1.0.0.json"
+
     @abstractmethod
     def _created(self, entry):
         """Returns the creation date."""
@@ -125,7 +129,7 @@ class CommunityEntry(Entry):
         self._load_partial(
             entry,
             transformed,
-            ["files", "metadata", "access"],
+            [("$schema", "schema"), "files", "metadata", "access"],
             prefix="json",
         )
         return transformed

--- a/invenio_rdm_migrator/streams/models/affiliations.py
+++ b/invenio_rdm_migrator/streams/models/affiliations.py
@@ -8,6 +8,7 @@
 """Affiliation model."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -23,6 +24,6 @@ class Affiliation(Model):
     id: Mapped[UUID] = mapped_column(primary_key=True)
     pid: Mapped[str]
     json: Mapped[dict]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]

--- a/invenio_rdm_migrator/streams/models/awards.py
+++ b/invenio_rdm_migrator/streams/models/awards.py
@@ -8,6 +8,7 @@
 """Awards models."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -23,6 +24,6 @@ class Awards(Model):
     id: Mapped[UUID] = mapped_column(primary_key=True)
     pid: Mapped[str]
     json: Mapped[dict]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]

--- a/invenio_rdm_migrator/streams/models/communities.py
+++ b/invenio_rdm_migrator/streams/models/communities.py
@@ -82,6 +82,6 @@ class CommunityFile(Model):
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
     version_id: Mapped[int]
-    key: Mapped[str] = mapped_column(primary_key=True)
+    key: Mapped[str]
     record_id: Mapped[UUID]
     object_version_id: Mapped[UUID]

--- a/invenio_rdm_migrator/streams/models/communities.py
+++ b/invenio_rdm_migrator/streams/models/communities.py
@@ -8,6 +8,7 @@
 """Communities models."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -21,8 +22,8 @@ class Community(Model):
     __tablename__: InitVar[str] = "communities_metadata"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     json: Mapped[dict] = mapped_column(nullable=True)
     version_id: Mapped[int]
     slug: Mapped[str]
@@ -46,8 +47,8 @@ class CommunityMember(Model):
     __tablename__: InitVar[str] = "communities_members"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     json: Mapped[dict] = mapped_column(nullable=True)
     version_id: Mapped[int]
     role: Mapped[str]
@@ -66,9 +67,9 @@ class FeaturedCommunity(Model):
 
     community_id: Mapped[UUID]
     id: Mapped[int] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
-    start_date: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
+    start_date: Mapped[datetime]
 
 
 class CommunityFile(Model):
@@ -76,8 +77,8 @@ class CommunityFile(Model):
 
     __tablename__: InitVar[str] = "communities_files"
 
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
     version_id: Mapped[int]

--- a/invenio_rdm_migrator/streams/models/files.py
+++ b/invenio_rdm_migrator/streams/models/files.py
@@ -27,11 +27,11 @@ class FilesBucket(Model):
     updated: Mapped[datetime]
     default_location: Mapped[int]
     default_storage_class: Mapped[str]
-    size: Mapped[int]
-    quota_size: Mapped[int] = mapped_column(BigInteger(), nullable=True)
-    max_file_size: Mapped[int] = mapped_column(BigInteger(), nullable=True)
+    size: Mapped[int] = mapped_column(BigInteger(), nullable=False)
     locked: Mapped[bool]
     deleted: Mapped[bool]
+    quota_size: Mapped[int] = mapped_column(BigInteger(), nullable=True)
+    max_file_size: Mapped[int] = mapped_column(BigInteger(), nullable=True)
 
 
 class FilesInstance(Model):
@@ -44,7 +44,7 @@ class FilesInstance(Model):
     updated: Mapped[datetime]
     uri: Mapped[str] = mapped_column(nullable=True)
     storage_class: Mapped[str] = mapped_column(nullable=True)
-    size: Mapped[int] = mapped_column(nullable=True)
+    size: Mapped[int] = mapped_column(BigInteger(), nullable=True)
     checksum: Mapped[str] = mapped_column(nullable=True)
     readable: Mapped[bool]
     writable: Mapped[bool]

--- a/invenio_rdm_migrator/streams/models/files.py
+++ b/invenio_rdm_migrator/streams/models/files.py
@@ -8,6 +8,7 @@
 """Files models."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -22,8 +23,8 @@ class FilesBucket(Model):
     __tablename__: InitVar[str] = "files_bucket"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     default_location: Mapped[int]
     default_storage_class: Mapped[str]
     size: Mapped[int]
@@ -39,15 +40,15 @@ class FilesInstance(Model):
     __tablename__: InitVar[str] = "files_files"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     uri: Mapped[str] = mapped_column(nullable=True)
     storage_class: Mapped[str] = mapped_column(nullable=True)
     size: Mapped[int] = mapped_column(nullable=True)
     checksum: Mapped[str] = mapped_column(nullable=True)
     readable: Mapped[bool]
     writable: Mapped[bool]
-    last_check_at: Mapped[str] = mapped_column(nullable=True)  # datetime
+    last_check_at: Mapped[datetime] = mapped_column(nullable=True)
     last_check: Mapped[bool]
 
 
@@ -57,8 +58,8 @@ class FilesObjectVersion(Model):
     __tablename__: InitVar[str] = "files_object"
 
     version_id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     key: Mapped[str]
     bucket_id: Mapped[UUID]
     file_id: Mapped[UUID] = mapped_column(nullable=True)

--- a/invenio_rdm_migrator/streams/models/funders.py
+++ b/invenio_rdm_migrator/streams/models/funders.py
@@ -8,6 +8,7 @@
 """Funders models."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -23,6 +24,6 @@ class Funders(Model):
     id: Mapped[UUID] = mapped_column(primary_key=True)
     pid: Mapped[str]
     json: Mapped[dict]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]

--- a/invenio_rdm_migrator/streams/models/github.py
+++ b/invenio_rdm_migrator/streams/models/github.py
@@ -8,6 +8,7 @@
 """Dataclasses models to generate table rows for OAI-PMH."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -21,8 +22,8 @@ class WebhookEvent(Model):
     __tablename__: InitVar[str] = "webhooks_events"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]
-    updated: Mapped[str]
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     receiver_id: Mapped[str]
     user_id: Mapped[int] = mapped_column(nullable=True)
     payload: Mapped[dict] = mapped_column(nullable=True)
@@ -38,8 +39,8 @@ class Repository(Model):
     __tablename__: InitVar[str] = "github_repositories"
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
-    created: Mapped[str]
-    updated: Mapped[str]
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     github_id: Mapped[int] = mapped_column(nullable=True)
     name: Mapped[str]
     user_id: Mapped[int] = mapped_column(nullable=True)
@@ -51,8 +52,8 @@ class Release(Model):
 
     __tablename__: InitVar[str] = "github_releases"
 
-    created: Mapped[str]
-    updated: Mapped[str]
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     id: Mapped[UUID] = mapped_column(primary_key=True)
     release_id: Mapped[int] = mapped_column(nullable=True)
     tag: Mapped[str] = mapped_column(nullable=True)

--- a/invenio_rdm_migrator/streams/models/names.py
+++ b/invenio_rdm_migrator/streams/models/names.py
@@ -8,6 +8,7 @@
 """Name model."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -20,8 +21,8 @@ class Name(Model):
 
     __tablename__: InitVar[str] = "name_metadata"
 
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict]
     version_id: Mapped[int]

--- a/invenio_rdm_migrator/streams/models/oai.py
+++ b/invenio_rdm_migrator/streams/models/oai.py
@@ -8,6 +8,7 @@
 """Dataclasses models to generate table rows for OAI-PMH."""
 
 from dataclasses import InitVar
+from datetime import datetime
 
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,5 +27,5 @@ class OAISet(Model):
     search_pattern: Mapped[str] = mapped_column(nullable=True)
     system_created: Mapped[bool] = mapped_column(nullable=False)
 
-    created: Mapped[str]
-    updated: Mapped[str]
+    created: Mapped[datetime]
+    updated: Mapped[datetime]

--- a/invenio_rdm_migrator/streams/models/oauth.py
+++ b/invenio_rdm_migrator/streams/models/oauth.py
@@ -7,6 +7,7 @@
 
 """Dataclasses OAuth models to generate table rows."""
 from dataclasses import InitVar
+from datetime import datetime
 
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -22,8 +23,8 @@ class RemoteAccount(Model):
     user_id: Mapped[int]
     client_id: Mapped[str]
     extra_data: Mapped[dict]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
 
 
 class RemoteToken(Model):
@@ -35,8 +36,8 @@ class RemoteToken(Model):
     token_type: Mapped[str] = mapped_column(primary_key=True)
     access_token: Mapped[str]
     secret: Mapped[str]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
 
 
 class ServerClient(Model):
@@ -66,7 +67,7 @@ class ServerToken(Model):
     user_id: Mapped[int] = mapped_column(nullable=True)
     access_token: Mapped[str] = mapped_column(nullable=True)
     refresh_token: Mapped[str] = mapped_column(nullable=True)
-    expires: Mapped[str] = mapped_column(nullable=True)  # datetime
+    expires: Mapped[datetime] = mapped_column(nullable=True)
     _scopes: Mapped[str] = mapped_column(nullable=True)
     token_type: Mapped[str] = mapped_column(nullable=True, default="bearer")
     is_personal: Mapped[bool] = mapped_column(nullable=True, default=False)

--- a/invenio_rdm_migrator/streams/models/pids.py
+++ b/invenio_rdm_migrator/streams/models/pids.py
@@ -7,6 +7,7 @@
 
 """Dataclasses models to generate table rows."""
 
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -25,8 +26,8 @@ class PersistentIdentifier(Model):
     status: Mapped[str]
     object_type: Mapped[str] = mapped_column(nullable=True)
     object_uuid: Mapped[UUID] = mapped_column(nullable=True)
-    created: Mapped[str]
-    updated: Mapped[str]
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     # default since we do not take it into account in many places
     # ant it's not in the data
     pid_provider: Mapped[str] = mapped_column(nullable=True, default=None)

--- a/invenio_rdm_migrator/streams/models/records.py
+++ b/invenio_rdm_migrator/streams/models/records.py
@@ -70,9 +70,9 @@ class RDMDraftMetadata(Model):
     index: Mapped[int]
     bucket_id: Mapped[UUID]
     parent_id: Mapped[UUID]
-    expires_at: Mapped[datetime]
+    expires_at: Mapped[datetime] = mapped_column(nullable=True, default=None)
     # in a new version this value is None
-    fork_version_id: Mapped[int] = mapped_column(nullable=True)
+    fork_version_id: Mapped[int] = mapped_column(nullable=True, default=None)
     media_bucket_id: Mapped[UUID] = mapped_column(nullable=True, default=None)
 
 

--- a/invenio_rdm_migrator/streams/models/records.py
+++ b/invenio_rdm_migrator/streams/models/records.py
@@ -8,6 +8,7 @@
 """Dataclasses record models to generate table rows."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -22,8 +23,8 @@ class RDMRecordMetadata(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     index: Mapped[int]
     bucket_id: Mapped[UUID]
@@ -39,8 +40,8 @@ class RDMParentMetadata(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
 
 
@@ -63,13 +64,13 @@ class RDMDraftMetadata(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     index: Mapped[int]
     bucket_id: Mapped[UUID]
     parent_id: Mapped[UUID]
-    expires_at: Mapped[str]
+    expires_at: Mapped[datetime]
     # in a new version this value is None
     fork_version_id: Mapped[int] = mapped_column(nullable=True)
     media_bucket_id: Mapped[UUID] = mapped_column(nullable=True, default=None)
@@ -82,8 +83,8 @@ class RDMRecordFile(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     key: Mapped[str]
     record_id: Mapped[UUID]
@@ -97,8 +98,8 @@ class RDMRecordMediaFile(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     key: Mapped[str]
     record_id: Mapped[UUID]
@@ -114,8 +115,8 @@ class RDMDraftFile(Model):
     # which in our case do not play any role
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     key: Mapped[str]
     record_id: Mapped[UUID]
@@ -129,8 +130,8 @@ class RDMDraftMediaFile(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     key: Mapped[str]
     record_id: Mapped[UUID]

--- a/invenio_rdm_migrator/streams/models/requests.py
+++ b/invenio_rdm_migrator/streams/models/requests.py
@@ -8,6 +8,7 @@
 """Requests models."""
 
 from dataclasses import InitVar
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped, mapped_column
@@ -22,8 +23,8 @@ class RequestMetadata(Model):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     json: Mapped[dict] = mapped_column(nullable=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     version_id: Mapped[int]
     number: Mapped[str]
-    expires_at: Mapped[str]  # datetime
+    expires_at: Mapped[datetime]

--- a/invenio_rdm_migrator/streams/models/users.py
+++ b/invenio_rdm_migrator/streams/models/users.py
@@ -8,6 +8,7 @@
 """Dataclasses user models to generate table rows."""
 
 from dataclasses import InitVar
+from datetime import datetime
 
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,19 +21,19 @@ class User(Model):
     __tablename__: InitVar[str] = "accounts_user"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     username: Mapped[str] = mapped_column(nullable=True)
     displayname: Mapped[str] = mapped_column(nullable=True)
     email: Mapped[str]
     password: Mapped[str]
     active: Mapped[bool]
-    confirmed_at: Mapped[str] = mapped_column(nullable=True)  # datetime
+    confirmed_at: Mapped[datetime] = mapped_column(nullable=True)
     version_id: Mapped[int]
     profile: Mapped[dict] = mapped_column(nullable=True)
     preferences: Mapped[dict] = mapped_column(nullable=True)
-    blocked_at: Mapped[str] = mapped_column(nullable=True, default=None)  # datetime
-    verified_at: Mapped[str] = mapped_column(nullable=True, default=None)  # datetime
+    blocked_at: Mapped[datetime] = mapped_column(nullable=True, default=None)
+    verified_at: Mapped[datetime] = mapped_column(nullable=True, default=None)
 
 
 class LoginInformation(Model):
@@ -42,8 +43,8 @@ class LoginInformation(Model):
 
     user_id: Mapped[int] = mapped_column(primary_key=True)
     # the initial creation has them all to None
-    last_login_at: Mapped[str] = mapped_column(nullable=True)  # datetime
-    current_login_at: Mapped[str] = mapped_column(nullable=True)  # datetime
+    last_login_at: Mapped[datetime] = mapped_column(nullable=True)
+    current_login_at: Mapped[datetime] = mapped_column(nullable=True)
     last_login_ip: Mapped[str] = mapped_column(nullable=True)
     current_login_ip: Mapped[str] = mapped_column(nullable=True)
     login_count: Mapped[int]
@@ -55,8 +56,8 @@ class SessionActivity(Model):
     __tablename__: InitVar[str] = "accounts_user_session_activity"
 
     user_id: Mapped[int]
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     sid_s: Mapped[str] = mapped_column(primary_key=True)
     ip: Mapped[str] = mapped_column(nullable=True)
     country: Mapped[str] = mapped_column(nullable=True)
@@ -71,8 +72,8 @@ class UserIdentity(Model):
 
     __tablename__: InitVar[str] = "accounts_useridentity"
 
-    created: Mapped[str]  # datetime
-    updated: Mapped[str]  # datetime
+    created: Mapped[datetime]
+    updated: Mapped[datetime]
     id: Mapped[str] = mapped_column(primary_key=True)
     method: Mapped[str] = mapped_column(primary_key=True)
     id_user: Mapped[int]

--- a/invenio_rdm_migrator/streams/records/transform.py
+++ b/invenio_rdm_migrator/streams/records/transform.py
@@ -47,6 +47,10 @@ class RDMRecordTransform(Transform):
 class RDMRecordEntry(Entry):
     """Transform a single record entry."""
 
+    def _schema(self, entry):
+        """Return JSONSchema of the record."""
+        return "local://records/record-v6.0.0.json"
+
     @abstractmethod
     def _id(self, entry):
         """Returns the rdm record uuid."""
@@ -136,6 +140,7 @@ class RDMRecordEntry(Entry):
             "bucket_id": self._bucket_id(entry),
             "media_bucket_id": self._media_bucket_id(entry),
             "json": {
+                "$schema": self._schema(entry),
                 "id": self._recid(entry),
                 "pids": self._pids(entry),
                 "files": self._files(entry),

--- a/invenio_rdm_migrator/transform/identity.py
+++ b/invenio_rdm_migrator/transform/identity.py
@@ -7,8 +7,6 @@
 
 """Invenio RDM migration transform interfaces."""
 
-from functools import partial
-
 from .base import Transform
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests =
 universal = 1
 
 [pydocstyle]
-add_ignore = D401,D403
+add_ignore = D103,D401,D403
 
 [isort]
 profile=black

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import tempfile
 
 import pytest
 
+from invenio_rdm_migrator.load.postgresql.transactions.execute import PostgreSQLTx
 from invenio_rdm_migrator.state import STATE, StateDB
 from invenio_rdm_migrator.streams.records.state import ParentModelValidator
 
@@ -38,6 +39,28 @@ def state(tmp_dir):
     STATE.initialized_state(state_db, cache=False, search_cache=False)
 
     return STATE
+
+
+@pytest.fixture(scope="function")
+def pg_tx(db_uri, session):
+    """PostgreSQLTx load configured with test session."""
+    return PostgreSQLTx(
+        db_uri=db_uri,
+        _session=session,
+        dry=False,
+        raise_on_db_error=True,
+    )
+
+
+@pytest.fixture(scope="function")
+def pg_tx_dry(db_uri, session):
+    """PostgreSQLTx load configured with test session and dry run."""
+    return PostgreSQLTx(
+        db_uri=db_uri,
+        _session=session,
+        dry=True,
+        raise_on_db_error=True,
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/load/test_load_transactions.py
+++ b/tests/load/test_load_transactions.py
@@ -82,18 +82,13 @@ def test_item(database, session):
     session.commit()
 
 
-@pytest.fixture(scope="function")
-def pg_tx(db_uri, session):
-    return PostgreSQLTx(db_uri=db_uri, _session=session, dry=False)
-
-
 ###
 # Operation Type
 ###
 
 
 def test_load_transaction_insert(session, pg_tx, database):
-    tx = [TestLoadAction(data={"tx_id": 1, "id": 101, "test": "insert test"})]
+    tx = [TestLoadAction(data={"tx": None, "id": 101, "test": "insert test"})]
     pg_tx.run(tx)
 
     result = session.query(TestModel).all()
@@ -107,14 +102,14 @@ def test_load_transaction_insert(session, pg_tx, database):
 
 
 def test_load_transaction_delete(pg_tx, session, database, test_item):
-    tx = [TestLoadAction(data={"tx_id": 2, "id": 1})]
+    tx = [TestLoadAction(data={"tx": None, "id": 1})]
     pg_tx.run(tx)
 
     session.query(TestModel).all()
 
 
 def test_load_transaction_update(pg_tx, session, database, test_item):
-    tx = [TestLoadAction(data={"tx_id": 1, "id": 1, "test": "update test"})]
+    tx = [TestLoadAction(data={"tx": None, "id": 1, "test": "update test"})]
     pg_tx.run(tx)
 
     result = session.query(TestModel).all()
@@ -137,8 +132,8 @@ def test_load_no_transaction(pg_tx, session, database):
 
 def test_load_transaction_multiple_actions(pg_tx, session, database):
     tx = [
-        TestLoadAction(data={"tx_id": 1, "id": 101, "test": "first instance"}),
-        TestLoadAction(data={"tx_id": 2, "id": 102, "test": "second instance"}),
+        TestLoadAction(data={"tx": None, "id": 101, "test": "first instance"}),
+        TestLoadAction(data={"tx": None, "id": 102, "test": "second instance"}),
     ]
     pg_tx.run(tx)
 

--- a/tests/streams/actions/conftest.py
+++ b/tests/streams/actions/conftest.py
@@ -9,6 +9,40 @@
 
 import pytest
 
+from invenio_rdm_migrator.streams.models.communities import (
+    Community,
+    CommunityFile,
+    CommunityMember,
+    FeaturedCommunity,
+    RDMParentCommunityMetadata,
+)
+from invenio_rdm_migrator.streams.models.files import (
+    FilesBucket,
+    FilesInstance,
+    FilesObjectVersion,
+)
+from invenio_rdm_migrator.streams.models.github import Release, Repository, WebhookEvent
+from invenio_rdm_migrator.streams.models.oai import OAISet
+from invenio_rdm_migrator.streams.models.oauth import (
+    RemoteAccount,
+    RemoteToken,
+    ServerClient,
+    ServerToken,
+)
+from invenio_rdm_migrator.streams.models.pids import PersistentIdentifier
+from invenio_rdm_migrator.streams.models.records import (
+    RDMDraftFile,
+    RDMDraftMetadata,
+    RDMParentMetadata,
+    RDMVersionState,
+)
+from invenio_rdm_migrator.streams.models.users import (
+    LoginInformation,
+    SessionActivity,
+    User,
+    UserIdentity,
+)
+
 
 ###
 # Draft
@@ -233,3 +267,52 @@ def fr_data(ov_data):
         "record_id": None,
         "object_version_id": ov_data["version_id"],
     }
+
+
+@pytest.fixture(scope="session")
+def database(engine):
+    """Setup database.
+
+    Scope: module
+
+    Normally, tests should use the function-scoped :py:data:`db` fixture
+    instead. This fixture takes care of creating the database/tables and
+    removing the tables once tests are done.
+    """
+    tables = [
+        Community,
+        CommunityFile,
+        CommunityMember,
+        FeaturedCommunity,
+        FilesBucket,
+        FilesInstance,
+        FilesObjectVersion,
+        LoginInformation,
+        OAISet,
+        PersistentIdentifier,
+        RDMDraftMetadata,
+        RDMDraftFile,
+        RDMParentMetadata,
+        RDMVersionState,
+        RDMParentCommunityMetadata,
+        RemoteAccount,
+        RemoteToken,
+        Release,
+        Repository,
+        ServerClient,
+        ServerToken,
+        SessionActivity,
+        User,
+        UserIdentity,
+        WebhookEvent,
+    ]
+
+    # create tables
+    for model in tables:
+        model.__table__.create(bind=engine, checkfirst=True)
+
+    yield
+
+    # remove tables
+    for model in tables:
+        model.__table__.drop(engine)

--- a/tests/streams/actions/test_files_actions.py
+++ b/tests/streams/actions/test_files_actions.py
@@ -7,40 +7,146 @@
 
 """File actions tests."""
 
-from uuid import UUID
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from testutils import assert_model_count
 
 from invenio_rdm_migrator.load.postgresql.transactions.operations import OperationType
-from invenio_rdm_migrator.streams.actions.load import DraftFileUploadAction
+from invenio_rdm_migrator.streams.actions.load import FileUploadAction
 from invenio_rdm_migrator.streams.models.files import (
     FilesBucket,
     FilesInstance,
     FilesObjectVersion,
 )
-from invenio_rdm_migrator.streams.models.records import RDMDraftFile
+from invenio_rdm_migrator.streams.models.records import (
+    RDMDraftFile,
+    RDMDraftMediaFile,
+    RDMDraftMetadata,
+)
 
 
-def test_upload_file_action(
-    buckets_state, bucket_data_w_size, fi_data, ov_data, fr_data
+@pytest.fixture(scope="function")
+def draft(
+    session,
+    database,
+    bucket_data_w_size,
 ):
+    """Draft with bucket."""
+    session.add(FilesBucket(**bucket_data_w_size))
+    session.add(
+        RDMDraftMetadata(
+            id="5cbdc04b-b2ab-4d25-b21c-3ce6a5269710",
+            json={},
+            created=datetime.utcnow(),
+            updated=datetime.utcnow(),
+            version_id=1,
+            index=1,
+            bucket_id=bucket_data_w_size["id"],
+            parent_id=uuid4(),
+            expires_at=None,
+            fork_version_id=None,
+            media_bucket_id=None,
+        )
+    )
+    session.commit()
+
+
+@pytest.fixture(scope="function")
+def draft_with_file(session, draft, fi_data, ov_data, fr_data):
+    """Draft with one file."""
+    session.add(FilesInstance(**fi_data))
+    session.add(FilesObjectVersion(**ov_data))
+    fr_data["id"] = uuid4()
+    fr_data["record_id"] = "5cbdc04b-b2ab-4d25-b21c-3ce6a5269710"
+    session.add(RDMDraftFile(**fr_data))
+    session.commit()
+
+
+def test_upload_file(
+    session,
+    database,
+    pg_tx,
+    draft,
+    bucket_data_w_size,
+    fi_data,
+    ov_data,
+    fr_data,
+):
+    """Test draft file upload replacement."""
     data = dict(
-        tx_id=1,
         bucket=bucket_data_w_size,
         object_version=ov_data,
         file_instance=fi_data,
         file_record=fr_data,
     )
-    action = DraftFileUploadAction(data)
-    rows = list(action.prepare())
+    action = FileUploadAction(data)
+    rows = list(action.prepare(session))
 
     assert len(rows) == 4
-    assert rows[0].type == OperationType.UPDATE
-    assert rows[0].model == FilesBucket
-    assert rows[1].type == OperationType.INSERT
-    assert rows[1].model == FilesObjectVersion
-    assert rows[2].type == OperationType.INSERT
-    assert rows[2].model == FilesInstance
-    assert rows[3].type == OperationType.INSERT
-    assert rows[3].model == RDMDraftFile
-    UUID(rows[3].data["id"])  # would raise value error if not UUID or None
+    bucket, fi, ov, draft_file = rows
+    assert bucket.type == OperationType.UPDATE
+    assert bucket.model == FilesBucket
+    assert fi.type == OperationType.INSERT
+    assert fi.model == FilesInstance
+    assert ov.type == OperationType.INSERT
+    assert ov.model == FilesObjectVersion
+    assert draft_file.type == OperationType.INSERT
+    assert draft_file.model == RDMDraftFile
     # still type str since it has not been inserted in DB
-    assert rows[3].data["record_id"] == "d94f793c-47d2-48e2-9867-ca597b4ebb41"
+    assert str(draft_file.data["record_id"]) == "5cbdc04b-b2ab-4d25-b21c-3ce6a5269710"
+    assert str(draft_file.data["object_version_id"]) == ov_data["version_id"]
+
+    pg_tx.run([action])
+    assert_model_count(session, FilesBucket, 1)
+    assert_model_count(session, FilesObjectVersion, 1)
+    assert_model_count(session, FilesInstance, 1)
+    assert_model_count(session, RDMDraftFile, 1)
+
+
+def test_upload_file_replacement(
+    session,
+    database,
+    pg_tx,
+    draft_with_file,
+    bucket_data_w_size,
+    fi_data,
+    ov_data,
+    fr_data,
+):
+    """Test draft file upload replacement."""
+    fi_data["id"] = str(uuid4())
+    ov_data["file_id"] = fi_data["id"]
+    ov_data["version_id"] = str(uuid4())
+    data = dict(
+        bucket=bucket_data_w_size,
+        object_version=ov_data,
+        file_instance=fi_data,
+        file_record=fr_data,
+    )
+    action = FileUploadAction(data)
+    rows = list(action.prepare(session))
+
+    assert len(rows) == 5
+    bucket, old_ov, fi, new_ov, draft_file = rows
+    assert bucket.type == OperationType.UPDATE
+    assert bucket.model == FilesBucket
+    assert old_ov.type == OperationType.UPDATE
+    assert old_ov.model == FilesObjectVersion
+    assert str(old_ov.data["version_id"]) == "f8200dc7-55b6-4785-abd0-f3d13b143c98"
+    assert fi.type == OperationType.INSERT
+    assert fi.model == FilesInstance
+    assert new_ov.type == OperationType.INSERT
+    assert new_ov.model == FilesObjectVersion
+    assert draft_file.type == OperationType.UPDATE
+    assert draft_file.model == RDMDraftFile
+    assert str(draft_file.data["record_id"]) == "5cbdc04b-b2ab-4d25-b21c-3ce6a5269710"
+    assert str(draft_file.data["object_version_id"]) == ov_data["version_id"]
+
+    pg_tx.run([action])
+    assert_model_count(session, FilesBucket, 1)
+    assert_model_count(session, FilesObjectVersion, 2)
+    assert_model_count(session, FilesInstance, 2)
+    assert_model_count(session, RDMDraftFile, 1)

--- a/tests/streams/actions/test_github_actions.py
+++ b/tests/streams/actions/test_github_actions.py
@@ -59,40 +59,40 @@ def event_data():
     }
 
 
-def test_github_repo_update(gh_repo_data):
-    data = dict(tx_id=1, gh_repository=gh_repo_data)
+def test_github_repo_update(session, gh_repo_data):
+    data = dict(gh_repository=gh_repo_data)
     action = RepoUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == Repository
 
 
-def test_github_hook_event_create_wo_token(event_data):
-    data = dict(tx_id=1, webhook_event=event_data)
+def test_github_hook_event_create_wo_token(session, event_data):
+    data = dict(webhook_event=event_data)
     action = HookEventCreateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.INSERT
     assert rows[0].model == WebhookEvent
 
 
-def test_github_hook_event_create_w_token(event_data):
-    data = dict(tx_id=1, webhook_event=event_data)
+def test_github_hook_event_create_w_token(session, event_data):
+    data = dict(webhook_event=event_data)
     action = HookEventCreateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.INSERT
     assert rows[0].model == WebhookEvent
 
 
-def test_github_hook_event_update(event_data):
-    data = dict(tx_id=1, webhook_event=event_data)
+def test_github_hook_event_update(session, event_data):
+    data = dict(webhook_event=event_data)
     action = HookEventUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE
@@ -121,10 +121,10 @@ def gh_release_data():
     }
 
 
-def test_github_release_receive(gh_repo_data, gh_release_data):
-    data = dict(tx_id=1, gh_release=gh_release_data, gh_repository=gh_repo_data)
+def test_github_release_receive(session, gh_repo_data, gh_release_data):
+    data = dict(gh_release=gh_release_data, gh_repository=gh_repo_data)
     action = ReleaseReceiveAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 2
     assert rows[0].type == OperationType.UPDATE
@@ -133,10 +133,10 @@ def test_github_release_receive(gh_repo_data, gh_release_data):
     assert rows[1].model == Release
 
 
-def test_github_release_update(gh_release_data):
-    data = dict(tx_id=1, gh_release=gh_release_data)
+def test_github_release_update(session, gh_release_data):
+    data = dict(gh_release=gh_release_data)
     action = ReleaseUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE

--- a/tests/streams/actions/test_oauth_actions.py
+++ b/tests/streams/actions/test_oauth_actions.py
@@ -66,14 +66,13 @@ def oauth_token_data():
     }
 
 
-def test_create_oauth_server_token(oauth_client_data, oauth_token_data):
+def test_create_oauth_server_token(session, oauth_client_data, oauth_token_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
         token=oauth_token_data,
     )
     action = OAuthServerTokenCreateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 2
     assert rows[0].type == OperationType.INSERT
@@ -82,14 +81,13 @@ def test_create_oauth_server_token(oauth_client_data, oauth_token_data):
     assert rows[1].model == ServerToken
 
 
-def test_client_oauth_server_token(oauth_client_data, oauth_token_data):
+def test_client_oauth_server_token(session, oauth_client_data, oauth_token_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
         token=oauth_token_data,
     )
     action = OAuthServerTokenUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 2
     assert rows[0].type == OperationType.UPDATE
@@ -98,89 +96,84 @@ def test_client_oauth_server_token(oauth_client_data, oauth_token_data):
     assert rows[1].model == ServerToken
 
 
-def test_client_oauth_server_token_only_client(oauth_client_data):
+def test_client_oauth_server_token_only_client(session, oauth_client_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
     )
     action = OAuthServerTokenUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == ServerClient
 
 
-def test_client_oauth_server_token_only_server(oauth_token_data):
+def test_client_oauth_server_token_only_server(session, oauth_token_data):
     data = dict(
-        tx_id=1,
         token=oauth_token_data,
     )
     action = OAuthServerTokenUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == ServerToken
 
 
-def test_delete_oauth_server_token(oauth_client_data, oauth_token_data):
+def test_delete_oauth_server_token(session, oauth_client_data, oauth_token_data):
     data = dict(
-        tx_id=1,
         token=oauth_token_data,
     )
     action = OAuthServerTokenDeleteAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.DELETE
     assert rows[0].model == ServerToken
 
 
-def test_delete_oauth_server_token_w_client(oauth_client_data, oauth_token_data):
+def test_delete_oauth_server_token_w_client(
+    session, oauth_client_data, oauth_token_data
+):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
         token=oauth_token_data,
     )
     action = OAuthServerTokenDeleteAction(data)
     with pytest.raises(AssertionError):
-        list(action.prepare())
+        list(action.prepare(session))
 
 
-def test_create_oauth_application(oauth_client_data):
+def test_create_oauth_application(session, oauth_client_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
     )
     action = OAuthApplicationCreateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.INSERT
     assert rows[0].model == ServerClient
 
 
-def test_update_oauth_application(oauth_client_data):
+def test_update_oauth_application(session, oauth_client_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
     )
     action = OAuthApplicationUpdateAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == ServerClient
 
 
-def test_delete_oauth_application(oauth_client_data):
+def test_delete_oauth_application(session, oauth_client_data):
     data = dict(
-        tx_id=1,
         client=oauth_client_data,
     )
     action = OAuthApplicationDeleteAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 1
     assert rows[0].type == OperationType.DELETE
@@ -231,16 +224,18 @@ def account_user_identity():
 
 
 def test_connect_minimal_oauth_account(
-    oauth_remote_account, oauth_remote_token, account_user_identity
+    session,
+    oauth_remote_account,
+    oauth_remote_token,
+    account_user_identity,
 ):
     data = dict(
-        tx_id=1,
         remote_account=oauth_remote_account,
         remote_token=oauth_remote_token,
         user_identity=account_user_identity,
     )
     action = OAuthLinkedAccountConnectAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 3
     assert rows[0].type == OperationType.INSERT
@@ -252,6 +247,7 @@ def test_connect_minimal_oauth_account(
 
 
 def test_connect_full_oauth_account(
+    session,
     oauth_remote_account,
     oauth_remote_token,
     account_user_identity,
@@ -259,7 +255,6 @@ def test_connect_full_oauth_account(
     oauth_token_data,
 ):
     data = dict(
-        tx_id=1,
         remote_account=oauth_remote_account,
         remote_token=oauth_remote_token,
         user_identity=account_user_identity,
@@ -267,7 +262,7 @@ def test_connect_full_oauth_account(
         server_token=oauth_token_data,
     )
     action = OAuthLinkedAccountConnectAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 5
     assert rows[0].type == OperationType.INSERT
@@ -283,16 +278,18 @@ def test_connect_full_oauth_account(
 
 
 def test_disconnect_oauth_account(
-    oauth_remote_account, oauth_remote_token, account_user_identity
+    session,
+    oauth_remote_account,
+    oauth_remote_token,
+    account_user_identity,
 ):
     data = dict(
-        tx_id=1,
         remote_account=oauth_remote_account,
         remote_token=oauth_remote_token,
         user_identity=account_user_identity,
     )
     action = OAuthLinkedAccountDisconnectAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 3
     assert rows[0].type == OperationType.DELETE
@@ -303,14 +300,13 @@ def test_disconnect_oauth_account(
     assert rows[2].model == RemoteAccount
 
 
-def test_disconnect_gh_oauth_account(oauth_token_data, account_user_identity):
+def test_disconnect_gh_oauth_account(session, oauth_token_data, account_user_identity):
     data = dict(
-        tx_id=1,
         token=oauth_token_data,
         user_identity=account_user_identity,
     )
     action = OAuthGHDisconnectToken(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
 
     assert len(rows) == 2
     assert rows[0].type == OperationType.DELETE

--- a/tests/streams/actions/test_user_actions.py
+++ b/tests/streams/actions/test_user_actions.py
@@ -84,10 +84,10 @@ def sessions_data():
     ]
 
 
-def test_register_new_user(secret_keys_state, user_data, login_info_data):
-    data = dict(tx_id=1, user=user_data, login_information=login_info_data)
+def test_register_new_user(session, secret_keys_state, user_data, login_info_data):
+    data = dict(user=user_data, login_information=login_info_data)
     action = UserRegistrationAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
     assert len(rows) == 2
     assert rows[0].type == OperationType.INSERT
     assert rows[0].model == User
@@ -95,10 +95,10 @@ def test_register_new_user(secret_keys_state, user_data, login_info_data):
     assert rows[1].model == LoginInformation
 
 
-def test_edit_user(secret_keys_state, user_data, login_info_data):
-    data = dict(tx_id=1, user=user_data, login_information=login_info_data)
+def test_edit_user(session, secret_keys_state, user_data, login_info_data):
+    data = dict(user=user_data, login_information=login_info_data)
     action = UserEditAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
     assert len(rows) == 2
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == User
@@ -106,14 +106,14 @@ def test_edit_user(secret_keys_state, user_data, login_info_data):
     assert rows[1].model == LoginInformation
 
 
-def test_deactivate_user(secret_keys_state, user_data, sessions_data):
+def test_deactivate_user(session, secret_keys_state, user_data, sessions_data):
     # prepare
     user_data["active"] = False
 
     # test
-    data = dict(tx_id=1, user=user_data, sessions=sessions_data)
+    data = dict(user=user_data, sessions=sessions_data)
     action = UserDeactivationAction(data)
-    rows = list(action.prepare())
+    rows = list(action.prepare(session))
     assert len(rows) == 3
     assert rows[0].type == OperationType.UPDATE
     assert rows[0].model == User

--- a/tests/streams/communities/test_communities_transform.py
+++ b/tests/streams/communities/test_communities_transform.py
@@ -110,6 +110,7 @@ def test_community_entry():
         "version_id": 1,
         "slug": "migrator",
         "json": {
+            "$schema": "local://communities/communities-v1.0.0.json",
             "files": None,
             "access": None,
             "metadata": {

--- a/tests/streams/files/test_files_load.py
+++ b/tests/streams/files/test_files_load.py
@@ -46,31 +46,49 @@ def test_files_load_prepare(files_copy_load, transformed_files_entry):
     with open(f"{files_copy_load.tmp_dir}/files_bucket.csv", "r") as file:
         # id, created, updated, default_location, default_storage_class, size, quota_size, max_file_size,locked, deleted
         expected = (
-            "1," "2023-04-19," "2023-04-19," "1," "L," "1234," "," "," "False," "False"
+            "1",
+            "2023-04-19",
+            "2023-04-19",
+            "1",
+            "L",
+            "1234",
+            "False",
+            "False",
+            "",
+            "",
         )
         content = file.read().rstrip()
-        assert content == expected
+        assert content == ",".join(expected)
     # assert files object version content
     with open(f"{files_copy_load.tmp_dir}/files_files.csv", "r") as file:
         # id, created, updated, uri, storage_class, size, checksum, readable, writable, last_check_at, last_check
         expected = (
-            "3,"
-            "2023-04-19,"
-            "2023-04-19,"
-            "path/to/file,"
-            "L,"
-            "1234,"
-            "md5:abcd1234,"
-            "True,"
-            "True,"
-            ","
-            "False"
+            "3",
+            "2023-04-19",
+            "2023-04-19",
+            "path/to/file",
+            "L",
+            "1234",
+            "md5:abcd1234",
+            "True",
+            "True",
+            "",
+            "False",
         )
         content = file.read().rstrip()
-        assert content == expected
+        assert content == ",".join(expected)
     # assert files instance content
     with open(f"{files_copy_load.tmp_dir}/files_object.csv", "r") as file:
         #  version_id, created, updated, key, bucket_id, file_id, _mimetype, is_head
-        expected = "2," "2023-04-19," "2023-04-19," "file.txt," "1," "3," "," "True"
+        expected = (
+            "2",
+            "2023-04-19",
+            "2023-04-19",
+            "file.txt",
+            "1",
+            "3",
+            "",
+            "True",
+        )
         content = file.read().rstrip()
-        assert content == expected
+        assert content == ",".join(expected)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Invenio-RDM-Migrator is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test utilities."""
+
+import sqlalchemy as sa
+
+
+def assert_model_count(session, model_cls, count):
+    """Assert row count for a model."""
+    assert session.scalar(sa.select(sa.func.count()).select_from(model_cls)) == count

--- a/tests/transform/test_transactions.py
+++ b/tests/transform/test_transactions.py
@@ -75,7 +75,7 @@ class TestTransformAction(TransformAction):
         record = next(o["after"] for o in self.tx.operations if o["table"] == "records")
         record["json"]["titles"] = [record["json"].pop("title")]
         return dict(
-            tx_id=self.tx.id,
+            tx=self.tx,
             record=record,
             files=[o["after"] for o in self.tx.operations if o["table"] == "files"],
         )
@@ -92,7 +92,7 @@ def test_transform_returns_load_action(tx):
     load_action = transform._transform(tx)
     assert isinstance(load_action, TestLoadAction)
     assert isinstance(load_action.data, TestLoadData)
-    assert load_action.data.tx_id == 1
+    assert load_action.data.tx == tx
     assert load_action.data.record == {"id": "abc", "json": {"titles": ["Test title"]}}
     assert load_action.data.files == [
         # NOTE: Order doesn't really matter here


### PR DESCRIPTION
- load: switch session.execute for applying operations
- load: fix operations datetime serialization
- load: add logging for SQL execute
- load: configurable logging
- models: use BigInteger for file size
- actions: fix draft upload transaction order
- files: split into separate actions
- actions: pass entire Tx throughout the stream
- actions: rely on DB queries instead of state
- models: fix nullable draft metadata fields
- actions: fix unused users edit profile action
- transform: add $schema to community and record
- actions: fix Tx grouping utility
- transform: add parameter for raising on error
- actions: refactor draft actions
